### PR TITLE
Remove unneeded remove section

### DIFF
--- a/satysfi-fonts-theano-doc.opam
+++ b/satysfi-fonts-theano-doc.opam
@@ -31,9 +31,3 @@ install: [
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
-remove: [
-  ["satyrographos" "opam" "uninstall"
-   "-name" "fonts-theano-doc"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
-]

--- a/satysfi-fonts-theano.opam
+++ b/satysfi-fonts-theano.opam
@@ -33,9 +33,3 @@ install: [
    "-prefix" "%{prefix}%"
    "-script" "%{build}%/Satyristes"]
 ]
-remove: [
-  ["satyrographos" "opam" "uninstall"
-   "-name" "fonts-theano"
-   "-prefix" "%{prefix}%"
-   "-script" "%{build}%/Satyristes"]
-]


### PR DESCRIPTION
As OPAM 2.0 tracks installed files, `remove` section is useless now.